### PR TITLE
fix: axsync should enable multitask and irq to work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ axerrno = {git = "https://github.com/Starry-OS/axerrno.git", optional=true}
 axtask = {git = "https://github.com/Starry-OS/axtask.git", optional=true}
 axlog = {git = "https://github.com/Starry-OS/axlog.git", optional=true}
 axhal = {git = "https://github.com/Starry-OS/axhal.git", optional=true}
-axsync = {git = "https://github.com/Starry-OS/axsync.git", optional=true}
+axsync = {git = "https://github.com/Starry-OS/axsync.git", features = ["multitask", "irq"], optional=true}


### PR DESCRIPTION


And `arceos` feature also needs https://github.com/Starry-OS/taskctx/pull/9 to merge to compile on latest nightly rustc.